### PR TITLE
Add test for .html.haml file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,5 @@ gemfiles/*.lock
 # Dummy Rails app
 /spec/dummy/db/
 /spec/dummy/log/
-/spec/dummy/tmp/
 
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ If you'd like to use `Tilt::HamlTemplate` in Sprockets, add code like this:
 register_engine ".haml", Grease.apply(Tilt::HamlTemplate), mime_type: "text/html", silence_deprecation: true
 
 # Sprockets 4+
-register_mime_type "text/haml", extensions: %w(.haml)
+register_mime_type "text/haml", extensions: %w(.haml .html.haml)
 register_transformer "text/haml", "text/html", Grease.apply(Tilt::HamlTemplate)
 ```
 

--- a/spec/dummy/app/assets/templates/bar.html.haml
+++ b/spec/dummy/app/assets/templates/bar.html.haml
@@ -1,0 +1,6 @@
+!!!
+%html{ lang: "ja" }
+  %head
+    %meta{ charset: "utf-8" }
+  %body
+    Hello world!

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -25,13 +25,13 @@ module Dummy
       if major_version == 3
         env.register_engine ".haml", Grease.apply(Tilt::HamlTemplate), mime_type: "text/html", silence_deprecation: true
       elsif major_version >= 4
-        env.register_mime_type "text/haml", extensions: %w(.haml)
+        env.register_mime_type "text/haml", extensions: %w(.haml .html.haml)
         env.register_transformer "text/haml", "text/html", Grease.apply(Tilt::HamlTemplate)
       end
     end
 
     # NOTE: Enable us to get the template path by ActionController::Base.helpers.asset_path
-    config.assets.precompile << "foo.html"
+    config.assets.precompile += %w(foo.html bar.html)
   end
 end
 

--- a/spec/tasks/assets/precompile_spec.rb
+++ b/spec/tasks/assets/precompile_spec.rb
@@ -6,21 +6,26 @@ describe "rake assets:precompile" do
   end
 
   describe "precompiled templates" do
-    subject { File.read(digest_path) }
-
-    let(:basename) { "foo.html" }
-    let(:source_path) { Rails.root.join("app/assets/templates", basename.sub(/\.html\z/, ".haml")) }
-    let(:digest_path) { File.join(Rails.public_path, ActionController::Base.helpers.asset_path(basename)) }
-
-    before do
+    before(:context) do
       Rake::Task["assets:precompile"].execute
     end
 
-    it { is_expected.to eq Tilt::HamlTemplate.new(source_path).render }
+    %w(foo.haml bar.html.haml).each do |basename|
+      logical_path = "#{basename.split(".").first}.html"
 
-    after do
+      describe logical_path do
+        subject { File.read(File.join(Rails.public_path, asset_path)) }
+
+        let(:asset_path) { ActionController::Base.helpers.asset_path(logical_path) }
+        let(:source_path) { Rails.root.join("app/assets/templates", basename) }
+
+        it { is_expected.to eq Tilt::HamlTemplate.new(source_path).render }
+      end
+    end
+
+    after(:context) do
       Rake::Task["assets:clobber"].execute
-      Rake::Task["tmp:cache:clear"].execute
+      FileUtils.rm_rf(Rails.root.join("tmp/cache"))
     end
   end
 end


### PR DESCRIPTION
# Summary

This PR adds test for `.html.haml` file because file types are no longer "chainable" in Sprockets 4.
ref. https://github.com/rails/sprockets/blob/master/guides/extending_sprockets.md#adding-erb-support-to-your-extension
