### PR TITLE
Improve Grease::Adapter#inspect

### DIFF
--- a/lib/grease/adapter.rb
+++ b/lib/grease/adapter.rb
@@ -12,5 +12,9 @@ module Grease
       data = template.render(context, {}).to_str
       context.metadata.merge(data: data)
     end
+
+    def inspect
+      "#<#{self.class.name}(#{@template_class.name}):#{format('%#016x', object_id << 1)}>"
+    end
   end
 end

--- a/spec/lib/grease/adapter_spec.rb
+++ b/spec/lib/grease/adapter_spec.rb
@@ -1,9 +1,12 @@
 require "spec_helper"
 
 RSpec.describe Grease::Adapter do
+  let(:adapter) { described_class.new(template_class) }
+  let(:template_class) { Tilt::ERBTemplate }
+
   describe "#call" do
     subject do
-      described_class.new(Tilt::ERBTemplate).call(
+      adapter.call(
         data: "<%= Math::PI.round(2) %>",
         environment: Sprockets::Environment.new,
         filename: "/path/to/foo.html.erb",
@@ -12,5 +15,10 @@ RSpec.describe Grease::Adapter do
     end
 
     it { is_expected.to match a_hash_including(data: "3.14") }
+  end
+
+  describe "#inspect" do
+    subject { adapter.inspect }
+    it { is_expected.to match(/#<#{described_class.name}\(#{template_class.name}\):0x[0-9a-f]{14}>/) }
   end
 end


### PR DESCRIPTION
# Summary

This PR improves `Grease::Adapter#inspect` for better inspection.
# Changes

``` ruby
# before
[1] pry(main)> Grease::Adapter.new(Class)
=> #<Grease::Adapter:0x007fec42bd4580 @template_class=Class>

# after
[1] pry(main)> Grease::Adapter.new(Class)
=> #<Grease::Adapter(Class):0x007f83008f8b78>
```
