### PR TITLE
Fix failed coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.2
-  - 2.3.1
+  - 2.2.6
+  - 2.3.3
 gemfile:
   - gemfiles/sprockets3.gemfile
   - gemfiles/sprockets4.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,5 @@ gemfile:
 branches:
   only:
     - master
+after_script:
+  - '[ ${TRAVIS_EVENT_TYPE} != "pull_request" ] && [ ${TRAVIS_BRANCH} = "master" ] && bundle exec codeclimate-test-reporter'

--- a/grease.gemspec
+++ b/grease.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "appraisal", ">= 2.0.0"
   spec.add_development_dependency "bundler"
-  spec.add_development_dependency "codeclimate-test-reporter"
+  spec.add_development_dependency "codeclimate-test-reporter", "~> 1.0"
   spec.add_development_dependency "haml"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rails", ">= 4.2"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,15 +17,9 @@
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 
 require "simplecov"
-require "codeclimate-test-reporter"
 
 SimpleCov.start do
   add_filter "/spec/"
-
-  formatter SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::HTMLFormatter,
-    CodeClimate::TestReporter::Formatter
-  ])
 end
 
 require "grease"


### PR DESCRIPTION
# Description
Currently, grease fails to send CodeClimate test coverage due to the following error: 

```
Formatter CodeClimate::TestReporter::Formatter failed with CodeClimate::TestReporter::Formatter::InvalidSimpleCovResultError: undefined method `values' for #<SimpleCov::Result:0x00000008518aa8> (/home/travis/.rvm/gems/ruby-2.3.1/gems/codeclimate-test-reporter-1.0.3/lib/code_climate/test_reporter/formatter.rb:21:in `rescue in format')
```
ref. https://travis-ci.org/yasaichi/grease/jobs/175410595#L306

As I looked over it, I found it is caused because [codeclimate-test-reporter](https://github.com/codeclimate/ruby-test-reporter) v1 (released just 2 weeks ago) had some breaking changes.
This PR fixes it.

# Additional changes
Since Ruby 2.2.6 and 2.3.3 were released recently, I upgraded Ruby versions used for testing.