### PR TITLE
Improve dummy app's configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ gemfile:
 branches:
   only:
     - master
+before_install:
+  - 'gem update --system --no-doc'
 after_script:
   - '[ ${TRAVIS_EVENT_TYPE} != "pull_request" ] && [ ${TRAVIS_BRANCH} = "master" ] && bundle exec codeclimate-test-reporter'

--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ $ gem install grease
 If you'd like to use `Tilt::HamlTemplate` in Sprockets, add code like this:
 
 ```ruby
-# Sprockets 3
-register_engine ".haml", Grease.apply(Tilt::HamlTemplate), mime_type: "text/html", silence_deprecation: true
-
-# Sprockets 4+
 register_mime_type "text/haml", extensions: %w(.haml .html.haml)
 register_transformer "text/haml", "text/html", Grease.apply(Tilt::HamlTemplate)
 ```

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -20,14 +20,8 @@ module Dummy
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.assets.configure do |env|
-      major_version = Sprockets::VERSION.split(".").first.to_i
-
-      if major_version == 3
-        env.register_engine ".haml", Grease.apply(Tilt::HamlTemplate), mime_type: "text/html", silence_deprecation: true
-      elsif major_version >= 4
-        env.register_mime_type "text/haml", extensions: %w(.haml .html.haml)
-        env.register_transformer "text/haml", "text/html", Grease.apply(Tilt::HamlTemplate)
-      end
+      env.register_mime_type "text/haml", extensions: %w(.haml .html.haml)
+      env.register_transformer "text/haml", "text/html", Grease.apply(Tilt::HamlTemplate)
     end
 
     # NOTE: Enable us to get the template path by ActionController::Base.helpers.asset_path


### PR DESCRIPTION
# Description
This PR removes the unescessary configuration for Sprockets 3.

# Additional changes
* Run "gem update" to avoid `Gem::Ext::BuildError` (ref. https://github.com/sickill/rainbow/issues/49).