### PR TITLE
Revert dummy app configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ $ gem install grease
 When you'd like to use `Tilt::HamlTemplate` in Sprockets, add code like this:
 
 ```ruby
+# Sprockets 3
+register_engine ".haml", Grease.apply(Tilt::HamlTemplate), mime_type: Tilt::HamlTemplate.default_mime_type, silence_deprecation: true
+
+# Sprockets 4 or later
 register_mime_type "text/haml", extensions: %w(.haml .html.haml)
 register_transformer "text/haml", Tilt::HamlTemplate.default_mime_type, Grease.apply(Tilt::HamlTemplate)
 ```

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -19,9 +19,16 @@ module Dummy
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+
     config.assets.configure do |env|
-      env.register_mime_type "text/haml", extensions: %w(.haml .html.haml)
-      env.register_transformer "text/haml", "text/html", Grease.apply(Tilt::HamlTemplate)
+      major_version = Gem::Version.create(Sprockets::VERSION).segments.first
+
+      if major_version == 3
+        env.register_engine ".haml", Grease.apply(Tilt::HamlTemplate), mime_type: Tilt::HamlTemplate.default_mime_type, silence_deprecation: true
+      elsif major_version >= 4
+        env.register_mime_type "text/haml", extensions: %w(.haml .html.haml)
+        env.register_transformer "text/haml", Tilt::HamlTemplate.default_mime_type, Grease.apply(Tilt::HamlTemplate)
+      end
     end
 
     # NOTE: Enable us to get the template path by ActionController::Base.helpers.asset_path


### PR DESCRIPTION
This PR reverts the changes of #8 because Sprockets 3 has a bug that files not in the precompile list are compiled when using `register_mime_type` and `register_transformer`.
In this gem, you can see [`foo.haml` and `bar.haml` are generated](https://travis-ci.org/yasaichi/grease/jobs/196315509#L712-L715).

For further information:  https://github.com/rails/sprockets/issues/384