### PR TITLE
Test Sprockets::Rails::Helper methods

### DIFF
--- a/spec/dummy/app/assets/templates/bar.html.haml
+++ b/spec/dummy/app/assets/templates/bar.html.haml
@@ -2,5 +2,8 @@
 %html{ lang: "ja" }
   %head
     %meta{ charset: "utf-8" }
+    %title bar.html.haml
+    = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": true
+    = javascript_include_tag "application", "data-turbolinks-track": true
   %body
     Hello world!

--- a/spec/dummy/app/assets/templates/foo.haml
+++ b/spec/dummy/app/assets/templates/foo.haml
@@ -2,5 +2,8 @@
 %html{ lang: "ja" }
   %head
     %meta{ charset: "utf-8" }
+    %title foo.haml
+    = stylesheet_link_tag "application", media: "all", "data-turbolinks-track": true
+    = javascript_include_tag "application", "data-turbolinks-track": true
   %body
     Hello world!

--- a/spec/tasks/assets/precompile_spec.rb
+++ b/spec/tasks/assets/precompile_spec.rb
@@ -6,6 +6,9 @@ describe "rake assets:precompile" do
   end
 
   describe "precompiled templates" do
+    let(:env) { Rails.application.assets }
+    let(:context_class) { env.context_class }
+
     before(:context) do
       Rake::Task["assets:precompile"].execute
     end
@@ -14,12 +17,14 @@ describe "rake assets:precompile" do
       logical_path = "#{basename.split(".").first}.html"
 
       describe logical_path do
-        subject { File.read(File.join(Rails.public_path, asset_path)) }
+        describe "body" do
+          subject { File.read(File.join(Rails.public_path, context.asset_path(logical_path))) }
 
-        let(:asset_path) { ActionController::Base.helpers.asset_path(logical_path) }
-        let(:source_path) { Rails.root.join("app/assets/templates", basename) }
+          let(:context) { context_class.new(environment: env, filename: source_path, metadata: {}) }
+          let(:source_path) { Rails.root.join("app/assets/templates", basename) }
 
-        it { is_expected.to eq Tilt::HamlTemplate.new(source_path).render }
+          it { is_expected.to eq Tilt::HamlTemplate.new(source_path).render(context) }
+        end
       end
     end
 


### PR DESCRIPTION
This PR fixes `precompile_spec.rb` to check whether `Sprockets::Rails::Helper` methods written in templates work or not.