### PR TITLE
Remove an unnecessary argument passed to Tilt::Template#render

### DIFF
--- a/lib/grease/adapter.rb
+++ b/lib/grease/adapter.rb
@@ -8,9 +8,8 @@ module Grease
       context = input[:environment].context_class.new(input)
       template = @template_class.new { input[:data] }
 
-      # TODO: Hack for converting ActiveSupport::SafeBuffer into String
-      data = template.render(context, {}).to_str
-      context.metadata.merge(data: data)
+      # NOTE: Call #to_str to convert ActiveSupport::SafeBuffer into String
+      context.metadata.merge(data: template.render(context).to_str)
     end
 
     def inspect


### PR DESCRIPTION
This PR removes the 2nd argument passed to `Tilt::Template#render` because the default value is `{}`.
ref. https://github.com/rtomayko/tilt/blob/v2.0.6/lib/tilt/template.rb#L96