### PR TITLE
Fix failed tests due to Rails 5.2

### DIFF
--- a/spec/dummy/config/initializers/new_framework_defaults.rb
+++ b/spec/dummy/config/initializers/new_framework_defaults.rb
@@ -17,8 +17,5 @@ ActiveSupport.to_time_preserves_timezone = true
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
-
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }


### PR DESCRIPTION
This PR fixes the failed tests due to the deprecated option in Rails 5.2.