### PR TITLE
Run tests in Ruby 2.3 ~ 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.6
-  - 2.3.3
+  - 2.3.7
+  - 2.4.4
+  - 2.5.1
 gemfile:
   - gemfiles/sprockets3.gemfile
   - gemfiles/sprockets4.gemfile


### PR DESCRIPTION
This PR updates Ruby versions used to run tests in TravisCI.
It means to drop support for Ruby 2.2.