### PR TITLE
CI against the latest minor versions of Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.2.6
-  - 2.3.3
+  - 2.2.10
+  - 2.3.8
+  - 2.4.6
+  - 2.5.5
+  - 2.6.3
 gemfile:
   - gemfiles/sprockets3.gemfile
   - gemfiles/sprockets4.gemfile


### PR DESCRIPTION
This PR makes the tests run on the latest minor versions of Ruby (including Ruby 2.5 and 2.6).